### PR TITLE
Fix cursor color not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ require("bluloco").setup({
   transparent = false,
   italics = false,
   terminal = vim.fn.has("gui_running") == 1 -- bluoco colors are enabled in gui terminals per default.
+  guicursor   = true,
 })
 
 vim.cmd('colorscheme bluloco')
@@ -235,7 +236,7 @@ require('lualine').setup {
 
 ## Config
 
-### Style
+### style
 
 There are three styles you can configure here: `auto`, `dark` and `light`.  
 The `auto` setting is the default and will adjust automatically to your
@@ -244,7 +245,7 @@ The `auto` setting is the default and will adjust automatically to your
 > ℹ️ The style value only applies if you set the theme with `vim.cmd('colorscheme bluloco')`.  
 > Setting the theme with a variant directly will override this setting.
 
-### Transparency
+### transparency (default: false)
 
 This setting will disable the background and use the default background of your terminal.
 You need to enable this if you want the terminal to be transparent. You would still need to
@@ -253,11 +254,11 @@ configure your terminal accordingly for light and dark backgrounds when switchin
 <!-- TODO:  See: auto switching themes.
 See: bluloco theme for iTerm2 -->
 
-### Italics
+### italics (default: false)
 
 This setting will enable italics for _keywords_, _comments_ and _markup attributes_.
 
-### Terminal
+### terminal (default: true in gui, otherwise false)
 
 This setting will enable the bluloco colors in your integrated terminal. 
 You most likely want to keep your terminal colors instead of overriding them if you are running neovim in a terminal.
@@ -267,6 +268,11 @@ You can skip the `terminal` setting completely to have it disabled in terminals 
 
 > ℹ️  Please note that some terminals will display bold text as the bright color variant but enabling this feature will override this behavior in the intergrated terminal. This is by design and has nothing to do with this theme. [see](https://github.com/neovim/neovim/issues/11335)
 
+### guicursor (default: true)
+
+This setting sets a guicursor to fix your terminal cursor and make it colorful (as intended).
+It is enabled by default.
+If you want to override this, make sure to set your `:set guicursor` after loading the theme or disable it completely.
 
 <!-- ## Recipes
 ### Auto switching light & dark themes

--- a/lua/bluloco/init.lua
+++ b/lua/bluloco/init.lua
@@ -12,6 +12,9 @@ local defaultConfig = {
   terminal    = isGui
 }
 
+-- Set cursor color
+vim.opt.guicursor = "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,r-cr-o:hor20-Cursor"
+
 M.config = defaultConfig
 
 function M.setup(options)

--- a/lua/bluloco/init.lua
+++ b/lua/bluloco/init.lua
@@ -15,7 +15,7 @@ local defaultConfig = {
 
 -- Set cursor color
 if (defaultConfig.guicursor) then
-  vim.opt.guicursor = "n-v-c-sm:block-Cursor/lCursor,i-ci-ve:ver25-Cursor/lCursor,r-cr-o:hor20-Cursor/lCursor"
+  vim.opt.guicursor = "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,r-cr-o:hor20-Cursor"
 end
 
 M.config = defaultConfig

--- a/lua/bluloco/init.lua
+++ b/lua/bluloco/init.lua
@@ -9,11 +9,14 @@ local defaultConfig = {
   style       = "auto", -- auto | light | dark
   transparent = false,
   italics     = false,
-  terminal    = isGui
+  terminal    = isGui,
+  guicursor   = true,
 }
 
 -- Set cursor color
-vim.opt.guicursor = "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,r-cr-o:hor20-Cursor"
+if (defaultConfig.guicursor) then
+  vim.opt.guicursor = "n-v-c-sm:block-Cursor/lCursor,i-ci-ve:ver25-Cursor/lCursor,r-cr-o:hor20-Cursor/lCursor"
+end
 
 M.config = defaultConfig
 

--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -271,7 +271,6 @@ local theme = lush(function(injected_functions)
     SignColumn { Normal }, -- column where |signs| are displayed
     FoldColumn { SignColumn }, -- 'foldcolumn'
     Substitute { IncSearch }, -- |:substitute| replacement text highlighting
-    -- MatchParen { gui = "reverse" }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
     MatchParen { bg = t.punctuation, fg = t.bg }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
     ModeMsg { Normal }, -- 'showmode' message (e.g., "-- INSERT -- ")
     MsgArea { Normal }, -- Area for messages and cmdline
@@ -447,6 +446,11 @@ local theme = lush(function(injected_functions)
     -- html
     sym("@text.uri.html") { gui = "underline" },
 
+
+    -- -- gui vim
+    -- -- VimR
+    VimrDefaultCursor { fg = t.cursor, bg = t.bg },
+    VimrInsertCursor { fg = t.cursor, bg = t.bg },
 
     --  gitsigns
     GitSignsAdd { fg = t.added },

--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -254,8 +254,8 @@ local theme = lush(function(injected_functions)
     ColorColumn { Whitespace }, -- used for the columns set with 'colorcolumn'
     Conceal {}, -- placeholder characters substituted for concealed text (see 'conceallevel')
     Cursor { bg = t.cursor, fg = t.bg }, -- character under the cursor
-    lCursor { Normal }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
-    CursorIM { Normal }, -- like Cursor, but used when in IME mode |CursorIM|
+    lCursor { Cursor }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
+    CursorIM { Cursor }, -- like Cursor, but used when in IME mode |CursorIM|
     Directory { fg = t.keyword }, -- directory names (and other special names in listings)
     DiffAdd { bg = t.diffAdd }, -- diff mode: Added line |diff.txt|
     DiffChange { bg = t.diffChange }, -- diff mode: Changed line |diff.txt|


### PR DESCRIPTION
Cursor color was not working in terminal so the matching paren was looking weird. Fixed this by setting `guicursor` property. You can opt out of this if you set the `guicursor` config to false in the setup function, or override the setting yourself with your adjustments. 