### PR TITLE
Fix guicursor approach

### DIFF
--- a/lua/bluloco/init.lua
+++ b/lua/bluloco/init.lua
@@ -13,15 +13,15 @@ local defaultConfig = {
   guicursor   = true,
 }
 
--- Set cursor color
-if (defaultConfig.guicursor) then
-  vim.opt.guicursor = "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,r-cr-o:hor20-Cursor"
-end
-
 M.config = defaultConfig
 
 function M.setup(options)
   M.config = vim.tbl_deep_extend("force", {}, defaultConfig, options or {})
+
+  -- Set cursor color
+  if (M.config.guicursor) then
+    vim.opt.guicursor = "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,r-cr-o:hor20-Cursor"
+  end
 end
 
 function M.load()


### PR DESCRIPTION
This Pull Request fixes #58

The issue was caused by the approach with the guicursor. Previously, the theme always changed the `config.guicursor`, even when set to false in the setup function options, due to the following code snippet in the `lua/bluloco/init.lua` file:

```lua
-- Set cursor color
if (defaultConfig.guicursor) then
  vim.opt.guicursor = "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,r-cr-o:hor20-Cursor"
end
```
In this case, the `config.guicursor` would always be `true` because the comparison was with the `defaultConfig`, where it is always true.

The solution was basically to change when this happens, as follows:

```lua
function M.setup(options)
  M.config = vim.tbl_deep_extend("force", {}, defaultConfig, options or {})

  -- Set cursor color
  if (M.config.guicursor) then
    vim.opt.guicursor = "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,r-cr-o:hor20-Cursor"
  end
end

```

Now, the guicursor is updated if, and only if, the option guicursor in config is true.