### PR TITLE
Added a space to the name of the colour scheme

### DIFF
--- a/terminal-themes/xfce4terminal/BlulocoDark.theme
+++ b/terminal-themes/xfce4terminal/BlulocoDark.theme
@@ -1,5 +1,5 @@
 [Scheme]
-Name=BlulocoDark
+Name=Bluloco Dark
 ColorForeground=#b9c0cb
 ColorBackground=#282c34
 ColorCursor=#ffcc00

--- a/terminal-themes/xfce4terminal/BlulocoLight.theme
+++ b/terminal-themes/xfce4terminal/BlulocoLight.theme
@@ -1,5 +1,5 @@
 [Scheme]
-Name=BlulocoLight
+Name=Bluloco Light
 ColorForeground=#373a41
 ColorBackground=#f9f9f9
 ColorCursor=#f32759


### PR DESCRIPTION
This is so that the colour scheme name looks better in Xfce's terminal UI.