### PR TITLE
Added basic support for vim-fugitive

### DIFF
--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -465,8 +465,8 @@ local theme = lush(function(injected_functions)
     sym("@lsp.mod.readonly") { sym("@constant") },
     sym("@lsp.typemod.function.declaration") { sym("@function") },
     sym("@lsp.typemod.function.readonly") { sym("@function") },
-    -- -- gui vim
-    -- -- VimR
+    -- gui vim
+    -- VimR
     VimrDefaultCursor { fg = t.cursor, bg = t.bg },
     VimrInsertCursor { fg = t.cursor, bg = t.bg },
     --  gitsigns
@@ -570,9 +570,9 @@ local theme = lush(function(injected_functions)
     -- TelescopePromptNormal { fg = t.fg, bg = t.bg },
     -- TelescopeResultsNormal  {},
 
-    -- -- Border highlight groups.
-    -- --   Use TelescopeBorder to override the default.
-    -- --   Otherwise set them specifically
+    -- Border highlight groups.
+    -- Use TelescopeBorder to override the default.
+    -- Otherwise set them specifically
 
     TelescopeBorder { NormalFloat, fg = t.punctuation },
     -- TelescopePromptBorder  {},
@@ -791,9 +791,9 @@ local theme = lush(function(injected_functions)
     -- WhichKeyFloat {},
     -- WhichKeyBorder {},
     -- WhichKeyValue { Character },
-    --
-    --
-    --   -- Diffview
+
+
+    -- Diffview
     DiffviewStatusAdded { fg = t.method },
     DiffviewStatusModified { fg = t.keyword },
     DiffviewStatusRenamed { fg = t.keyword },
@@ -817,6 +817,11 @@ local theme = lush(function(injected_functions)
     -- DiffviewReference {},
     DiffviewPrimary { fg = t.keyword },
     DiffviewSecondary { fg = t.tag },
+    --
+
+    -- vim-fugitive
+    diffAdded { fg = t.method },
+    diffRemoved { fg = t.type },
     --
 
     -- nvim tree


### PR DESCRIPTION
Added the diffAdded and diffRemoved highlight groups, which have the same highlight as the DiffviewStatusAdded and DiffviewStatusDeleted highlight groups respectively.

I also removed some double comments, like:
— — Comment

Here is what it looks like:
![image](https://github.com/uloco/bluloco.nvim/assets/91734413/b205fb2b-e95f-42da-b1e1-e55a01180d7c)

Previously, it looked like this:
![image](https://github.com/uloco/bluloco.nvim/assets/91734413/070c79a8-a97c-4d22-b4cf-30c8e94c2f31)
