### PR TITLE
Update the treesitter highlight groups

### DIFF
--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -433,10 +433,10 @@ local theme = lush(function(injected_functions)
     sym("@warning") { WarningMsg },
     sym("@info") { fg = t.info },
     --
-    -- sym"@string.special"    { }, -- SpecialChar
-    -- sym"@character.special" { }, -- SpecialChar
-    -- sym"@function.macro"    { }, -- Macro
-    -- sym"@debug"             { }, -- Debug
+    -- sym("@markup.link.label")    { }, -- SpecialChar
+    -- sym("@character.special")    { }, -- SpecialChar
+    -- sym("@function.macro")       { }, -- Macro
+    -- sym("@keyword.debug")        { }, -- Debug
 
     -- Language Overrides
     -- JSON
@@ -446,7 +446,26 @@ local theme = lush(function(injected_functions)
     sym("@label.help") { sym("@text.uri") },
     -- html
     sym("@text.uri.html") { gui = "underline" },
-    --
+
+
+    -- Treesitter highlight groups update
+    -- Treesitter standard capture groups
+    sym("@variable.parameter") { sym("@parameter") },
+    sym("@variable.member") { sym("@field") },
+    sym("@module") { sym("@namespace") },
+    sym("@string.special.symbol") { sym("@symbol") },
+    sym("@markup.strong") { sym("@text.strong") },
+    sym("@markup.underline") { sym("@text.underline") },
+    sym("@markup.heading") { sym("@text.title") },
+    sym("@markup.link.url") { sym("@text.uri") },
+    sym("@markup.raw") { sym("@text.literal") },
+    sym("@markup.list") { sym("@punctuation.special") },
+
+    -- Helix capture groups
+    sym("@function.method") { sym("@method") },
+    sym("@string.special.url") { sym("@text.uri") },
+
+
     -- semantic highlighting
     sym("@lsp.type.namespace") { sym("@namespace") },
     sym("@lsp.type.type") { sym("@type") },
@@ -465,6 +484,7 @@ local theme = lush(function(injected_functions)
     sym("@lsp.mod.readonly") { sym("@constant") },
     sym("@lsp.typemod.function.declaration") { sym("@function") },
     sym("@lsp.typemod.function.readonly") { sym("@function") },
+
     -- gui vim
     -- VimR
     VimrDefaultCursor { fg = t.cursor, bg = t.bg },


### PR DESCRIPTION
This fixes #66.

The commented highlight groups have been changed outright as there's no backward compatibility to worry about. The highlight groups in use are not changed; instead, the new treesitter highlight groups have been linked to the old ones to keep backwards compatibility and only the highlight groups used by the theme are added.

References for the treesitter highlight group change:
1. https://github.com/nvim-treesitter/nvim-treesitter/commit/1ae9b0e4558fe7868f8cda2db65239cfb14836d0
2. https://www.reddit.com/r/neovim/comments/19aratu/psa_nvimtreesitter_breaking_changes_on_highlight/