### PR TITLE
Add @keyword.modifier

### DIFF
--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -415,6 +415,7 @@ local theme = lush(function(injected_functions)
     sym("@type.builtin") { fg = t.keyword },
     sym("@type.qualifier") { Statement },
     sym("@keyword") { Statement },
+    sym("@keyword.modifier") { Statement }, -- Same as @type.qualifier
     sym("@namespace") { Type },
     sym("@annotation") { sym("@label") }, -- For labels: `label:` in C and `:label:` in Lua.
     sym("@text") { Identifier },


### PR DESCRIPTION
This is to fix the breaking nvim-treesitter highlight change in https://github.com/nvim-treesitter/nvim-treesitter/commit/998b230a77b544761bae8aa7518d40b91a5c9559.

The old `@type.qualifier` hasn't been removed to maintain backward compatibility.

Fixes #70