### PR TITLE
Remove underlines when a buffer is selected

### DIFF
--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -537,11 +537,11 @@ local theme = lush(function(injected_functions)
     BufferlineFill { NormalFloat },
     BufferlineModified { fg = t.primary, bg = t.shade10 },
     BufferlineModifiedVisible { fg = t.primary, bg = t.shade8 },
-    BufferlineModifiedSelected { fg = t.primary, sp = t.primary, gui = "underline bold" },
+    BufferlineModifiedSelected { fg = t.primary, sp = t.primary, gui = "bold" },
 
     BufferlineError { bg = t.shade10, fg = t.error },
     BufferlineErrorVisible { bg = t.shade8, fg = t.error },
-    BufferlineErrorSelected { bg = t.bg, fg = t.error, sp = t.primary, gui = "underline bold" },
+    BufferlineErrorSelected { bg = t.bg, fg = t.error, sp = t.primary, gui = "bold" },
 
     BufferlineErrorDiagnostic { BufferlineError },
     BufferlineErrorDiagnosticVisible { BufferlineErrorVisible },
@@ -549,7 +549,7 @@ local theme = lush(function(injected_functions)
 
     BufferlineWarning { bg = t.shade10, fg = t.warning },
     BufferlineWarningVisible { bg = t.shade8, fg = t.warning },
-    BufferlineWarningSelected { bg = t.bg, fg = t.warning, sp = t.primary, gui = "underline bold" },
+    BufferlineWarningSelected { bg = t.bg, fg = t.warning, sp = t.primary, gui = "bold" },
 
     BufferlineWarningDiagnostic { BufferlineWarning },
     BufferlineWarningDiagnosticVisible { BufferlineWarningVisible },
@@ -557,7 +557,7 @@ local theme = lush(function(injected_functions)
 
     BufferlineInfo { bg = t.shade10, fg = t.info },
     BufferlineInfoVisible { bg = t.shade8, fg = t.info },
-    BufferlineInfoSelected { bg = t.bg, fg = t.info, sp = t.primary, gui = "underline bold" },
+    BufferlineInfoSelected { bg = t.bg, fg = t.info, sp = t.primary, gui = "bold" },
 
     BufferlineInfoDiagnostic { BufferlineInfo },
     BufferlineInfoDiagnosticVisible { BufferlineInfoVisible },
@@ -565,7 +565,7 @@ local theme = lush(function(injected_functions)
 
     BufferlineHint { bg = t.shade10, fg = t.hint },
     BufferlineHintVisible { bg = t.shade8, fg = t.hint },
-    BufferlineHintSelected { bg = t.bg, fg = t.hint, sp = t.primary, gui = "underline bold" },
+    BufferlineHintSelected { bg = t.bg, fg = t.hint, sp = t.primary, gui = "bold" },
 
     BufferlineHintDiagnostic { BufferlineHint },
     BufferlineHintDiagnosticVisible { BufferlineHintVisible },


### PR DESCRIPTION
This is a subjective change, so feel free to close this pull request if it is not up to your taste.

I prefer the look of having no underlines, mostly because the modified icon is also underlined, which doesn't look good. Below is a comparison:

Underlined:
![image](https://github.com/uloco/bluloco.nvim/assets/91734413/b03c5721-d821-4914-b69a-30ed19082adf)

No underlines:
![image](https://github.com/uloco/bluloco.nvim/assets/91734413/60b91466-fcc5-442c-be1b-6800bcf9713f)
