### PR TITLE
Add initial support for Snacks.nvim

### DIFF
--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -103,6 +103,7 @@ local dark = {
   rainbowGreen          = hsl("#92f535"),
   rainbowViolet         = hsl("#ff78ff"),
   rainbowCyan           = hsl("#28e4eb"),
+  rainbowIndigo         = hsl("#9F7EFE"),
 }
 
 local light = {
@@ -173,6 +174,7 @@ local light = {
   rainbowGreen          = hsl("#1fc255"),
   rainbowViolet         = hsl("#a557ff"),
   rainbowCyan           = hsl("#0e91a8"),
+  rainbowIndigo         = hsl("#383A42"),
 }
 
 local t = dark
@@ -972,7 +974,7 @@ local theme = lush(function(injected_functions)
     GitConflictAncestorLabel { bg = t.mergeParentLabel, blend = 5 },
     --
 
-    -- notify
+    -- nvim-notify
     NotifyBackground { NormalFloat },
     NotifyERRORBorder { Normal, fg = t.error },
     NotifyWARNBorder { Normal, fg = t.warning },
@@ -1024,6 +1026,39 @@ local theme = lush(function(injected_functions)
     RainbowDelimiterGreen { fg = t.rainbowGreen },
     RainbowDelimiterViolet { fg = t.rainbowViolet },
     RainbowDelimiterCyan { fg = t.rainbowCyan },
+
+    -- snacks.nvim
+
+    -- snacks.nvim indent
+    SnacksIndent { Whitespace },
+    -- SnacksIndentBlank { Whitespace },
+    SnacksIndentScope { LineNr },
+    -- SnacksIndentChunk { LineNr },
+    SnacksIndent1 { fg = t.rainbowRed },
+    SnacksIndent2 { fg = t.rainbowYellow },
+    SnacksIndent3 { fg = t.rainbowBlue },
+    SnacksIndent4 { fg = t.rainbowOrange },
+    SnacksIndent5 { fg = t.rainbowGreen },
+    SnacksIndent6 { fg = t.rainbowViolet },
+    SnacksIndent7 { fg = t.rainbowCyan },
+    SnacksIndent8 { fg = t.rainbowIndigo },
+
+    -- snacks.nvim notifier
+    SnacksNotifierBorderError { Normal, fg = t.error },
+    SnacksNotifierBorderWarn { Normal, fg = t.warning },
+    SnacksNotifierBorderInfo { Normal, fg = t.info },
+    SnacksNotifierBorderDebug { Normal, fg = t.punctuation },
+    SnacksNotifierBorderTrace { Normal, fg = t.property },
+    SnacksNotifierIconError { SnacksNotifierBorderError },
+    SnacksNotifierIconWarn { SnacksNotifierBorderWarn },
+    SnacksNotifierIconInfo { SnacksNotifierBorderInfo },
+    SnacksNotifierIconDebug { SnacksNotifierBorderDebug },
+    SnacksNotifierIconTrace { SnacksNotifierBorderTrace },
+    SnacksNotifierTitleError { SnacksNotifierBorderError },
+    SnacksNotifierTitleWarn { SnacksNotifierBorderWarn },
+    SnacksNotifierTitleInfo { SnacksNotifierBorderInfo },
+    SnacksNotifierTitleDebug { SnacksNotifierBorderDebug },
+    SnacksNotifierTitleTrace { SnacksNotifierBorderTrace },
 
     -- Neotest
     NeotestPassed { fg = t.added },


### PR DESCRIPTION
Screenshots of the notifier:

![image](https://github.com/user-attachments/assets/90313499-1316-4a00-8aa4-638c71c79c1d)

![image](https://github.com/user-attachments/assets/6ceeaf49-b83a-4ba3-90df-18ca18332057)

![image](https://github.com/user-attachments/assets/33814dee-5137-47bb-9ae1-2af9a529473c)

![image](https://github.com/user-attachments/assets/662a45d8-6fb0-46d7-8e91-f88a34e70b3c)

![image](https://github.com/user-attachments/assets/39d560bc-d55e-47a9-bdff-8aeb35fba8d6)

![image](https://github.com/user-attachments/assets/a14a2710-bc33-4e63-aa23-ece8ed113229)


Screenshot of the rainbow indent guides:

![image](https://github.com/user-attachments/assets/20f744bc-46d9-46d1-bb39-93cb4dfc8b49)


Screenshots of the default indent guide (follows [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim) defaults):

![image](https://github.com/user-attachments/assets/2abf316f-c64c-4fe8-bc60-ab80d1f513c2)

![image](https://github.com/user-attachments/assets/1d58fc9a-2a08-4c65-9455-9199302ce2c1)

<br>

---

<br>

I will probably need your input on the `SnacksIndent8` highlight group, as there are only 7 highlight groups for the rainbow-delimiters plugin. You can see that the highlight group repeats in the screenshot of the rainbow indent guides, as I just set the `SnacksIndent8` highlight group to be the same as the `SnacksIndent1` highlight group.