### PR TITLE
Add blink.cmp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Currently supported (aka. tested) plugins:
 - [git-conflict.nvim](https://github.com/akinsho/git-conflict.nvim)
 - [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim)
 - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
+- [blink.cmp](https://github.com/Saghen/blink.cmp)
 - [vim-which-key](https://github.com/liuchengxu/vim-which-key)
 - [which-key.nvim](https://github.com/folke/which-key.nvim)
 - [todo-comments.nvim](https://github.com/folke/todo-comments.nvim)

--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -830,7 +830,7 @@ local theme = lush(function(injected_functions)
     TroubleText {},
     --
 
-    -- Cmp
+    -- Nvim Cmp
     CmpDocumentation { fg = t.fg, bg = t.bgFloat },
     CmpDocumentationBorder { fg = t.punctuation, bg = t.bgFloat },
     CmpItemAbbr { fg = t.fg },
@@ -861,6 +861,40 @@ local theme = lush(function(injected_functions)
     CmpItemKindEnumMember { fg = t.type },
     CmpItemKindOperator { fg = t.punctuation },
     CmpItemKindSnippet { fg = t.label },
+    --
+
+    -- Blink Cmp
+    BlinkCmpDoc { fg = t.fg, bg = t.bgFloat },
+    BlinkCmpDocBorder { fg = t.punctuation, bg = t.bgFloat },
+    BlinkCmpLabel { fg = t.fg },
+    BlinkCmpLabelDeprecated { fg = t.fg, gui = "strikethrough" },
+    BlinkCmpLabelMatch { fg = t.primary },
+    BlinkCmpLabelDetail { fg = t.attribute },
+    BlinkCmpLabelDescription { fg = t.attribute },
+    BlinkCmpSource { fg = t.attribute },
+    BlinkCmpKindText { fg = t.comment },
+    BlinkCmpKindDefault { fg = t.fb },
+    BlinkCmpKindKeyword { fg = t.keyword },
+    BlinkCmpKindVariable { fg = t.fg },
+    BlinkCmpKindConstant { fg = t.constant },
+    BlinkCmpKindReference { fg = t.fg },
+    BlinkCmpKindValue { fg = t.fg },
+    BlinkCmpKindFunction { fg = t.method },
+    BlinkCmpKindMethod { fg = t.method },
+    BlinkCmpKindConstructor { fg = t.type },
+    BlinkCmpKindClass { fg = t.type },
+    BlinkCmpKindInterface { fg = t.type },
+    BlinkCmpKindStruct { fg = t.type },
+    BlinkCmpKindEvent { fg = t.label },
+    BlinkCmpKindEnum { fg = t.type },
+    BlinkCmpKindUnit { fg = t.number },
+    BlinkCmpKindModule { fg = t.keyword },
+    BlinkCmpKindProperty { fg = t.property },
+    BlinkCmpKindField { fg = t.property },
+    BlinkCmpKindTypeParameter { fg = t.type },
+    BlinkCmpKindEnumMember { fg = t.type },
+    BlinkCmpKindOperator { fg = t.punctuation },
+    BlinkCmpKindSnippet { fg = t.label },
     --
 
     -- nvim illuminate


### PR DESCRIPTION
Dark theme:

![image](https://github.com/user-attachments/assets/03702ea5-e20d-4240-9276-a13c21313434)

![image](https://github.com/user-attachments/assets/8f32e319-854c-47d2-bdff-65cfb48b2379)


Light theme:

![image](https://github.com/user-attachments/assets/78235ea9-1ea5-46df-a5cb-a36517debdba)

![image](https://github.com/user-attachments/assets/526a62ce-f950-452e-964e-bcfe2425d225)

I just copied the nvim-cmp highlight groups and mapped them to the [blink.cmp](https://github.com/Saghen/blink.cmp) highlight groups with the help of [`blink.cmp`'s `use_nvim_cmp` option](https://github.com/Saghen/blink.cmp/blob/a5402a1ae0ef71a3d47e5f82e35cefe7299ba508/lua/blink/cmp/highlights.lua#L4).

Here's the list of all the highlight groups:
https://cmp.saghen.dev/configuration/appearance.html