### PR TITLE
Add blink.cmp copilot kind

### DIFF
--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -867,6 +867,7 @@ local theme = lush(function(injected_functions)
     CmpItemKindSnippet { fg = t.label },
     CmpItemKindCopilot { fg = t.copilot },
     --
+
     -- Blink Cmp
     BlinkCmpDoc { fg = t.fg, bg = t.bgFloat },
     BlinkCmpDocBorder { fg = t.punctuation, bg = t.bgFloat },
@@ -899,6 +900,7 @@ local theme = lush(function(injected_functions)
     BlinkCmpKindEnumMember { fg = t.type },
     BlinkCmpKindOperator { fg = t.punctuation },
     BlinkCmpKindSnippet { fg = t.label },
+    BlinkCmpKindCopilot { fg = t.copilot },
     --
 
     -- nvim illuminate


### PR DESCRIPTION
Should this colour be used for other AI coding assistants too?

For example, there is [Supermaven](https://github.com/supermaven-inc/supermaven-nvim), [TabNine](https://github.com/tzachar/cmp-tabnine), and [Codeium](https://github.com/Exafunction/codeium.nvim).

I found Supermaven to work the best for me, and TabNine doesn't need an internet connection to work, but isn't very good.

I use these icons if it matters:

```lua
TabNine = "󰏚"
Supermaven = ""
Codeium = "󰘦"
Copilot = ""
```