### PR TITLE
Add initial support for the Snacks picker

### DIFF
--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -1074,6 +1074,7 @@ local theme = lush(function(injected_functions)
     RainbowDelimiterCyan { fg = t.rainbowCyan },
 
     -- snacks.nvim
+    -- SnacksNormal { NormalFloat },
 
     -- snacks.nvim indent
     SnacksIndent { Whitespace },
@@ -1105,6 +1106,26 @@ local theme = lush(function(injected_functions)
     SnacksNotifierTitleInfo { SnacksNotifierBorderInfo },
     SnacksNotifierTitleDebug { SnacksNotifierBorderDebug },
     SnacksNotifierTitleTrace { SnacksNotifierBorderTrace },
+
+    -- snacks.nvim picker
+    -- SnacksPicker { NormalFloat },
+    SnacksPickerBorder { NormalFloat, fg = t.punctuation },
+    SnacksPickerTitle { NormalFloat, fg = t.punctuation },
+    -- SnacksPickerCursorLine { CursorLine },
+    SnacksPickerSelected { fg = t.primary },
+    SnacksPickerSearch { Visual },
+    SnacksPickerMatch { fg = t.keyword },
+    SnacksPickerPrompt { fg = t.punctuation },
+    SnacksPickerCol { Number },
+    SnacksPickerRow { Number },
+    SnacksPickerFile { fg = t.fg },
+    SnacksPickerDir { Comment },
+    SnacksPickerBufFlags { fg = t.primary },
+    SnacksPickerGitStatusAdded { fg = t.method },
+    SnacksPickerGitStatusModified { fg = t.keyword },
+    SnacksPickerGitStatusRenamed { fg = t.keyword },
+    SnacksPickerGitStatusCopied { fg = t.keyword },
+    SnacksPickerGitStatusDeleted { fg = t.type },
 
     -- Neotest
     NeotestPassed { fg = t.added },


### PR DESCRIPTION
Light mode:

`buffers`:

![image](https://github.com/user-attachments/assets/541905ae-9d8e-4a82-93be-de91b9a1d413)

`grep`:

![image](https://github.com/user-attachments/assets/f2faf097-75cf-447d-baed-85d4965c05cf)

`registers`:

![image](https://github.com/user-attachments/assets/46315b8a-c325-4d40-9c5e-6588f3684e0e)

`files`:

![image](https://github.com/user-attachments/assets/caa58601-6dc5-47b2-aff4-4ee86b3759c5)

Dark mode:

`buffers`:

![image](https://github.com/user-attachments/assets/56daede2-543e-4b4d-b02f-aabb9a54af04)

`grep`:

![image](https://github.com/user-attachments/assets/89d335d0-3411-42b4-a425-3986f56b515e)

`registers`:

![image](https://github.com/user-attachments/assets/9fa568b9-ff4c-4f6d-9826-01e3e90da45a)

`files`:
![image](https://github.com/user-attachments/assets/1de35231-811d-4d22-964f-96301711d003)

I'm not sure what colour you would like for the buffer flags (`SnacksPickerBufFlags` highlight group, the 2 to 3 character string after the buffer number). It is by default set to `NonText`, but it makes the flag very difficult to see. There is no differentiation between the current and alternate buffers as well, so I couldn't just take the `fzf-lua` colours.

The coloured dots at the side of the `files` picker are the selection status of the item. It only appears when you select multiple items using the <kbd>Tab</kbd> key. It is controlled by the `SnacksPickerSelected` highlight group, which defaults to the `Number` highlight group.