### PR TITLE
Add more highlight groups for the Snacks picker

### DIFF
--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -1125,7 +1125,10 @@ local theme = lush(function(injected_functions)
     SnacksPickerGitStatusModified { fg = t.keyword },
     SnacksPickerGitStatusRenamed { fg = t.keyword },
     SnacksPickerGitStatusCopied { fg = t.keyword },
+    SnacksPickerGitStatusUnmerged { fg = t.number },
     SnacksPickerGitStatusDeleted { fg = t.type },
+    SnacksPickerGitStatusIgnored { fg = t.comment },
+    SnacksPickerGitStatusUntracked { fg = t.comment },
 
     -- Neotest
     NeotestPassed { fg = t.added },


### PR DESCRIPTION
This commit adds more git status highlight groups, which are based on the highlight groups for `Diffview`.