### PR TITLE
Fix default BlinkCmpKind to follow nvim-cmp CmpItemKind

### DIFF
--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -880,6 +880,7 @@ local theme = lush(function(injected_functions)
     BlinkCmpLabelDetail { fg = t.attribute },
     BlinkCmpLabelDescription { fg = t.attribute },
     BlinkCmpSource { fg = t.attribute },
+    BlinkCmpKind { Special },
     BlinkCmpKindText { fg = t.comment },
     BlinkCmpKindDefault { fg = t.fb },
     BlinkCmpKindKeyword { fg = t.keyword },


### PR DESCRIPTION
Reason: https://github.com/Saghen/blink.cmp/commit/7ae6d9d6f645f96fdf61350e7bb50a057d230999

I'm not sure what the rationale is for this change, since it no longer follows nvim-cmp and it doesn't look good either, in my opinion.