### PR TITLE
Add rainbow headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ require("bluloco").setup({
   transparent = false,
   italics = false,
   terminal = vim.fn.has("gui_running") == 1, -- bluoco colors are enabled in gui terminals per default.
-  guicursor   = true,
+  guicursor = true,
+  rainbow_headings = false,     -- if you want different colored headings for each heading level
 })
 
 vim.opt.termguicolors = true

--- a/lua/bluloco/init.lua
+++ b/lua/bluloco/init.lua
@@ -6,11 +6,12 @@ local M = {}
 local isGui = vim.fn.has("gui_running") == 1
 
 local defaultConfig = {
-  style       = "auto", -- auto | light | dark
-  transparent = false,
-  italics     = false,
-  terminal    = isGui,
-  guicursor   = true,
+  style            = "auto", -- auto | light | dark
+  transparent      = false,
+  italics          = false,
+  terminal         = isGui,
+  guicursor        = true,
+  rainbow_headings = false,
 }
 
 M.config = defaultConfig
@@ -55,6 +56,27 @@ function M.load()
         Comment { theme.Comment, gui = "italic" },
         sym("@tag.attribute") { theme["@tag.attribute"], gui = "italic" },
         sym("@annotation") { theme["@annotation"], gui = "italic" },
+      }
+    end)
+  end
+
+  -- rainbow headings
+  if (M.config.rainbow_headings == true) then
+    theme = lush.extends({ theme }).with(function(injected_functions)
+      local sym = injected_functions.sym
+      return {
+        sym("@markup.heading.1") { theme.RainbowRed },
+        sym("@markup.heading.2") { theme.RainbowYellow },
+        sym("@markup.heading.3") { theme.RainbowBlue },
+        sym("@markup.heading.4") { theme.RainbowOrange },
+        sym("@markup.heading.5") { theme.RainbowGreen },
+        sym("@markup.heading.6") { theme.RainbowViolet },
+        markdownH1 { theme.RainbowRed },
+        markdownH2 { theme.RainbowYellow },
+        markdownH3 { theme.RainbowBlue },
+        markdownH4 { theme.RainbowOrange },
+        markdownH5 { theme.RainbowGreen },
+        markdownH6 { theme.RainbowViolet },
       }
     end)
   end


### PR DESCRIPTION
This uses the first 6 of the rainbow delimiter colours, which is the ones in [this comment](https://github.com/uloco/bluloco.nvim/issues/102#issuecomment-2796329872).

Let me know if you would like to use other colours for the rainbow headings, or want a different name for the configuration option.

Closes #102.