### PR TITLE
Transparent float window

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ This setting sets a guicursor to fix your terminal cursor and make it colorful (
 It is enabled by default.
 If you want to override this, make sure to set your `:set guicursor` after loading the theme or disable it completely.
 
+### float_window (default: "default")
+
+Controls how floating windows look when `transparent` is enabled.
+The default keeps a solid float background for better contrast, while setting it to `"transparent"` will also make floating windows inherit your terminal background (useful if you prefer a fully transparent UI).
+
 <!-- ## Recipes
 ### Auto switching light & dark themes
  -->

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ require("bluloco").setup({
   terminal = vim.fn.has("gui_running") == 1, -- bluoco colors are enabled in gui terminals per default.
   guicursor = true,
   rainbow_headings = false,     -- if you want different colored headings for each heading level
+  float_window = "default" -- "default" | "transparent"
 })
 
 vim.opt.termguicolors = true

--- a/lua/bluloco/init.lua
+++ b/lua/bluloco/init.lua
@@ -12,6 +12,7 @@ local defaultConfig = {
   terminal         = isGui,
   guicursor        = true,
   rainbow_headings = false,
+  float_window = "default" -- default | transparent
 }
 
 M.config = defaultConfig

--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -1,6 +1,7 @@
 local lush = require('lush')
 local hsl = lush.hsl
 local config = require("bluloco").config
+local isTransparentFloatWindow = config.transparent and config.float_window == "transparent"
 
 -- Lush.hsl provides a number of convenience functions for:
 --
@@ -38,7 +39,7 @@ local config = require("bluloco").config
 local dark = {
   -- syntax
   bg                    = hsl("#282C34"),
-  bgFloat               = hsl("#21242D"),
+  bgFloat               = isTransparentFloatWindow and "NONE" or hsl("#21242D"),
   fg                    = hsl("#ABB2BF"),
   cursor                = hsl("#FFCC00"),
   keyword               = hsl("#10B1FE"),
@@ -111,7 +112,7 @@ local dark = {
 local light = {
   -- syntax
   bg                    = hsl("#F9F9F9"),
-  bgFloat               = hsl("#ECEDEE"),
+  bgFloat               = isTransparentFloatWindow and "NONE" or hsl("#ECEDEE"),
   fg                    = hsl("#383A42"),
   cursor                = hsl("#F31459"),
   keyword               = hsl("#0098DD"),


### PR DESCRIPTION
In this PR, I added configuration for the transparency of float window.
I added `float_window` configuration option allows users to set floating windows as transparent.
You can choose "default" (keeps existing background colors) and "transparent" (transparent background).


before
<img width="2861" height="1402" alt="image" src="https://github.com/user-attachments/assets/7494dace-1975-448a-a22d-f72626bc49a4" />

after
<img width="2722" height="1356" alt="image" src="https://github.com/user-attachments/assets/ea7f80a8-c41f-4d79-8186-05bdbdac2c31" />

(I uses picker of folke/snacks.nvim)