### PR TITLE
Add better CodeDiff suppport

### DIFF
--- a/lua/lush_theme/bluloco.lua
+++ b/lua/lush_theme/bluloco.lua
@@ -998,6 +998,17 @@ local theme = lush(function(injected_functions)
     DiffviewPrimary { fg = t.keyword },
     DiffviewSecondary { fg = t.tag },
 
+    -- codediff.nvim
+    CodeDiffGutterInsertNumber { fg = t.added },
+    CodeDiffGutterDeleteNumber { fg = t.deleted },
+    CodeDiffMoveTo { fg = t.changed },
+    CodeDiffMoveFrom { fg = t.changed.mix(t.bg, 35) },
+    CodeDiffFiller { fg = t.shade20 },
+    CodeDiffStatusAdded { fg = t.method },
+    CodeDiffStatusModified { fg = t.keyword },
+    CodeDiffStatusConflict { fg = t.number },
+    CodeDiffConflictSign { fg = t.number },
+
     -- vim-fugitive
     diffAdded { fg = t.method },
     diffRemoved { fg = t.type },


### PR DESCRIPTION
- [`424f5ea`](https://github.com/uloco/bluloco.nvim/commit/424f5ea) Add better CodeDiff suppport

**Diffstat**

```text
 lua/lush_theme/bluloco.lua | 11 +++++++++++
 1 file changed, 11 insertions(+)
```