### PR TITLE
Add tmux theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ repository for this, thanks @mbadolato!
 
 They are located at `terminal-themes/`. Please follow your terminals installation guide in how to apply them.
 
+### tmux
+
+A Bluloco theme for tmux (status bar, panes, messages, copy mode) is available at
+[`extra/tmux/`](./extra/tmux/), including an oh-my-tmux variant and a light/dark auto-switch recipe.
+
+```tmux
+source-file ~/.config/tmux/bluloco-dark.conf
+```
+
 ## Switching light and dark theme according your OS settings
 
 This themes light and dark variant are meant to be used during day and night.

--- a/extra/tmux/.config/tmux/bluloco-dark.conf
+++ b/extra/tmux/.config/tmux/bluloco-dark.conf
@@ -1,0 +1,66 @@
+# vim:ft=tmux
+
+## name: Bluloco Dark
+## author: Umut Topuzoğlu
+## license: LGPL-3.0
+## upstream: https://github.com/uloco/bluloco.nvim/blob/main/extra/tmux/.config/tmux/bluloco-dark.conf
+
+## blurb: A fancy and sophisticated dark designer color theme
+
+#: Base colors
+
+# bg        #282C34
+# fg        #ABB2BF
+# dim fg    #636D83
+# status bg #2D333E
+# border    #384252
+# primary   #3691FF
+# blue      #10B1FE
+# green     #3FC56B
+# yellow    #F9C859
+# red       #FF6480
+# purple    #9F7EFE
+# selection #274670
+
+#: Status bar
+
+set -g status-style "bg=#2D333E,fg=#ABB2BF"
+set -g status-left-style "bg=#2D333E,fg=#ABB2BF"
+set -g status-right-style "bg=#2D333E,fg=#ABB2BF"
+
+#: Windows
+
+set -g window-status-style "bg=default,fg=#636D83"
+set -g window-status-current-style "bg=#3691FF,fg=#282C34,bold"
+set -g window-status-last-style "bg=default,fg=#3691FF"
+set -g window-status-activity-style "bg=default,fg=#F9C859"
+set -g window-status-bell-style "bg=default,fg=#FF6480,blink,bold"
+
+#: Panes
+
+set -g pane-border-style "fg=#384252"
+set -g pane-active-border-style "fg=#3691FF"
+set -g display-panes-colour "#636D83"
+set -g display-panes-active-colour "#3691FF"
+
+#: Messages / command prompt
+
+set -g message-style "bg=#F9C859,fg=#282C34,bold"
+set -g message-command-style "bg=#282C34,fg=#F9C859,bold"
+
+#: Copy mode / clock
+
+set -g mode-style "bg=#274670,fg=#ABB2BF"
+set -g clock-mode-colour "#3691FF"
+
+%if #{>=:#{version},3.2}
+set -g copy-mode-match-style "bg=#274670,fg=#ABB2BF"
+set -g copy-mode-current-match-style "bg=#3691FF,fg=#282C34,bold"
+set -g copy-mode-mark-style "bg=#9F7EFE,fg=#282C34,bold"
+%endif
+
+#: Optional status bar content
+#: Uncomment to use, or keep your own status-left/status-right formats.
+
+# set -g status-left  " #S "
+# set -g status-right " %Y-%m-%d %H:%M "

--- a/extra/tmux/.config/tmux/bluloco-light.conf
+++ b/extra/tmux/.config/tmux/bluloco-light.conf
@@ -1,0 +1,66 @@
+# vim:ft=tmux
+
+## name: Bluloco Light
+## author: Umut Topuzoğlu
+## license: LGPL-3.0
+## upstream: https://github.com/uloco/bluloco.nvim/blob/main/extra/tmux/.config/tmux/bluloco-light.conf
+
+## blurb: A fancy and sophisticated light designer color theme
+
+#: Base colors
+
+# bg        #F9F9F9
+# fg        #383A42
+# dim fg    #A0A1A7
+# status bg #EDEDEE
+# border    #DEE1E3
+# primary   #0099E1
+# blue      #275FE4
+# green     #23974A
+# yellow    #C5A332
+# red       #D52753
+# purple    #823FF1
+# selection #D2ECFF
+
+#: Status bar
+
+set -g status-style "bg=#EDEDEE,fg=#383A42"
+set -g status-left-style "bg=#EDEDEE,fg=#383A42"
+set -g status-right-style "bg=#EDEDEE,fg=#383A42"
+
+#: Windows
+
+set -g window-status-style "bg=default,fg=#A0A1A7"
+set -g window-status-current-style "bg=#0099E1,fg=#F9F9F9,bold"
+set -g window-status-last-style "bg=default,fg=#0099E1"
+set -g window-status-activity-style "bg=default,fg=#C5A332"
+set -g window-status-bell-style "bg=default,fg=#D52753,blink,bold"
+
+#: Panes
+
+set -g pane-border-style "fg=#DEE1E3"
+set -g pane-active-border-style "fg=#0099E1"
+set -g display-panes-colour "#A0A1A7"
+set -g display-panes-active-colour "#0099E1"
+
+#: Messages / command prompt
+
+set -g message-style "bg=#C5A332,fg=#F9F9F9,bold"
+set -g message-command-style "bg=#F9F9F9,fg=#C5A332,bold"
+
+#: Copy mode / clock
+
+set -g mode-style "bg=#D2ECFF,fg=#383A42"
+set -g clock-mode-colour "#0099E1"
+
+%if #{>=:#{version},3.2}
+set -g copy-mode-match-style "bg=#D2ECFF,fg=#383A42"
+set -g copy-mode-current-match-style "bg=#0099E1,fg=#F9F9F9,bold"
+set -g copy-mode-mark-style "bg=#823FF1,fg=#F9F9F9,bold"
+%endif
+
+#: Optional status bar content
+#: Uncomment to use, or keep your own status-left/status-right formats.
+
+# set -g status-left  " #S "
+# set -g status-right " %Y-%m-%d %H:%M "

--- a/extra/tmux/.config/tmux/bluloco.conf
+++ b/extra/tmux/.config/tmux/bluloco.conf
@@ -1,0 +1,13 @@
+# vim:ft=tmux
+
+## name: Bluloco (auto light/dark)
+## author: Umut Topuzoğlu
+## license: LGPL-3.0
+## upstream: https://github.com/uloco/bluloco.nvim/blob/main/extra/tmux/.config/tmux/bluloco.conf
+
+## blurb: Sources bluloco-light.conf or bluloco-dark.conf depending on $BLULOCO_STYLE.
+## Defaults to dark. See extra/tmux/README.md for how to toggle this at runtime.
+
+if-shell '[ "$BLULOCO_STYLE" = "light" ]' \
+  'source-file ~/.config/tmux/bluloco-light.conf' \
+  'source-file ~/.config/tmux/bluloco-dark.conf'

--- a/extra/tmux/.config/tmux/oh-my-tmux/bluloco-dark.conf.local
+++ b/extra/tmux/.config/tmux/oh-my-tmux/bluloco-dark.conf.local
@@ -1,0 +1,27 @@
+# vim:ft=tmux
+
+## name: Bluloco Dark for oh-my-tmux
+## author: Umut Topuzoğlu
+## license: LGPL-3.0
+## upstream: https://github.com/uloco/bluloco.nvim/blob/main/extra/tmux/.config/tmux/oh-my-tmux/bluloco-dark.conf.local
+
+## Paste these tmux_conf_theme_colour_* assignments into your ~/.tmux.conf.local
+## (https://github.com/gpakosz/.tmux), replacing the defaults it ships with.
+
+tmux_conf_theme_colour_1="#21242D"    # status bg
+tmux_conf_theme_colour_2="#384252"    # pane border / inactive accent
+tmux_conf_theme_colour_3="#636D83"    # dim fg
+tmux_conf_theme_colour_4="#3691FF"    # primary (active window, active border)
+tmux_conf_theme_colour_5="#F9C859"    # yellow (message, bell)
+tmux_conf_theme_colour_6="#282C34"    # fg-on-accent (= bg)
+tmux_conf_theme_colour_7="#ABB2BF"    # fg
+tmux_conf_theme_colour_8="#282C34"    # fg-on-accent (= bg)
+tmux_conf_theme_colour_9="#10B1FE"    # session segment (blue)
+tmux_conf_theme_colour_10="#9F7EFE"   # second segment (purple)
+tmux_conf_theme_colour_11="#3FC56B"   # third segment (green)
+tmux_conf_theme_colour_12="#636D83"   # dim fg
+tmux_conf_theme_colour_13="#ABB2BF"   # fg
+tmux_conf_theme_colour_14="#282C34"   # fg-on-accent (= bg)
+tmux_conf_theme_colour_15="#282C34"   # fg-on-accent (= bg)
+tmux_conf_theme_colour_16="#FF6480"   # red (root/danger segment)
+tmux_conf_theme_colour_17="#ABB2BF"   # fg

--- a/extra/tmux/.config/tmux/oh-my-tmux/bluloco-light.conf.local
+++ b/extra/tmux/.config/tmux/oh-my-tmux/bluloco-light.conf.local
@@ -1,0 +1,27 @@
+# vim:ft=tmux
+
+## name: Bluloco Light for oh-my-tmux
+## author: Umut Topuzoğlu
+## license: LGPL-3.0
+## upstream: https://github.com/uloco/bluloco.nvim/blob/main/extra/tmux/.config/tmux/oh-my-tmux/bluloco-light.conf.local
+
+## Paste these tmux_conf_theme_colour_* assignments into your ~/.tmux.conf.local
+## (https://github.com/gpakosz/.tmux), replacing the defaults it ships with.
+
+tmux_conf_theme_colour_1="#ECEDEE"    # status bg
+tmux_conf_theme_colour_2="#DEE1E3"    # pane border / inactive accent
+tmux_conf_theme_colour_3="#A0A1A7"    # dim fg
+tmux_conf_theme_colour_4="#275FE4"    # primary (active window, active border)
+tmux_conf_theme_colour_5="#C5A332"    # yellow (message, bell)
+tmux_conf_theme_colour_6="#F9F9F9"    # fg-on-accent (= bg)
+tmux_conf_theme_colour_7="#383A42"    # fg
+tmux_conf_theme_colour_8="#F9F9F9"    # fg-on-accent (= bg)
+tmux_conf_theme_colour_9="#0099E1"    # session segment (blue)
+tmux_conf_theme_colour_10="#823FF1"   # second segment (purple)
+tmux_conf_theme_colour_11="#23974A"   # third segment (green)
+tmux_conf_theme_colour_12="#A0A1A7"   # dim fg
+tmux_conf_theme_colour_13="#383A42"   # fg
+tmux_conf_theme_colour_14="#F9F9F9"   # fg-on-accent (= bg)
+tmux_conf_theme_colour_15="#F9F9F9"   # fg-on-accent (= bg)
+tmux_conf_theme_colour_16="#D52753"   # red (root/danger segment)
+tmux_conf_theme_colour_17="#383A42"   # fg

--- a/extra/tmux/README.md
+++ b/extra/tmux/README.md
@@ -1,0 +1,59 @@
+# Bluloco for tmux
+
+Dark and light tmux themes for status bar, panes, messages and copy mode, using the same
+palette as the neovim theme.
+
+## Install
+
+Copy or `stow` the files onto your machine, e.g.
+
+```sh
+stow -d extra -t ~ tmux
+```
+
+which places the theme files at `~/.config/tmux/`. Then, in your `~/.tmux.conf`:
+
+```tmux
+source-file ~/.config/tmux/bluloco-dark.conf
+# or
+source-file ~/.config/tmux/bluloco-light.conf
+```
+
+## Switching light and dark
+
+`bluloco.conf` sources whichever variant `$BLULOCO_STYLE` points at (defaults to dark):
+
+```tmux
+source-file ~/.config/tmux/bluloco.conf
+```
+
+```sh
+tmux set-environment -g BLULOCO_STYLE light   # or dark
+tmux source-file ~/.config/tmux/bluloco.conf
+```
+
+You can bind this to a key in `~/.tmux.conf`, e.g.
+
+```tmux
+bind C-t run-shell 'tmux set-environment -g BLULOCO_STYLE "$(tmux show-environment -g BLULOCO_STYLE 2>/dev/null | grep -q light && echo dark || echo light)"; tmux source-file ~/.config/tmux/bluloco.conf'
+```
+
+or drive it from your OS appearance setting, e.g. on macOS:
+
+```sh
+if [ "$(defaults read -g AppleInterfaceStyle 2>/dev/null)" = "Dark" ]; then
+  tmux set-environment -g BLULOCO_STYLE dark
+else
+  tmux set-environment -g BLULOCO_STYLE light
+fi
+```
+
+pairs well with the [auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) recipe
+in the main [README](../../README.md#switching-light-and-dark-theme-according-your-os-settings).
+
+## oh-my-tmux
+
+If you use [oh-my-tmux](https://github.com/gpakosz/.tmux), paste the contents of
+[`oh-my-tmux/bluloco-dark.conf.local`](./.config/tmux/oh-my-tmux/bluloco-dark.conf.local) or
+[`oh-my-tmux/bluloco-light.conf.local`](./.config/tmux/oh-my-tmux/bluloco-light.conf.local)
+into your `~/.tmux.conf.local`, replacing the `tmux_conf_theme_colour_*` defaults it ships with.


### PR DESCRIPTION
Adds Bluloco dark/light themes for tmux, an oh-my-tmux variant, and a
BLULOCO_STYLE-driven auto light/dark wrapper, mirroring the existing
terminal-themes/ and extra/ layout. Closes #41.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S61vp4zhtRAeCwuGdaLT94